### PR TITLE
WIP, port over wrinkle code from internal code

### DIFF
--- a/cfg/demo_baselines.yaml
+++ b/cfg/demo_baselines.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------
@@ -48,7 +46,7 @@ env:
     oracle_reveal: 'False'  # If 'True', we compute the occlusion vector every time Blender is called (should only be True if using corner revealing demonstrator)
     use_depth: 'False'      # If 'True', we use depth images for the training process instead of color images
     use_dom_rand: 'True'    # If 'True', we use domain randomization (camera pose, color, etc.)
-
+    use_rgbd: 'False'
 
 # ------------------------------------------------------------------------------
 # Initialization parameters. Let's assume we can pinpoint one of the four
@@ -61,7 +59,7 @@ env:
 init:
     type: 'tier1'               # Options: tier1, tier2, tier3
     debug_matplotlib: False     # If we show matplotlib video of the initialization
-    render_opengl: False        # If we show opengl rendering
+    render_opengl: True         # If we show opengl rendering
 
 # ------------------------------------------------------------------------------
 # Logging. We add the date before the last `.log` in the file name.

--- a/cfg/demo_baselines_fixed_t1_color.yaml
+++ b/cfg/demo_baselines_fixed_t1_color.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------

--- a/cfg/demo_baselines_fixed_t1_depth.yaml
+++ b/cfg/demo_baselines_fixed_t1_depth.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------

--- a/cfg/demo_baselines_fixed_t2_color.yaml
+++ b/cfg/demo_baselines_fixed_t2_color.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------

--- a/cfg/demo_baselines_fixed_t2_depth.yaml
+++ b/cfg/demo_baselines_fixed_t2_depth.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------

--- a/cfg/demo_baselines_fixed_t3_color.yaml
+++ b/cfg/demo_baselines_fixed_t3_color.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------

--- a/cfg/demo_baselines_fixed_t3_depth.yaml
+++ b/cfg/demo_baselines_fixed_t3_depth.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------

--- a/cfg/demo_render.yaml
+++ b/cfg/demo_render.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------

--- a/cfg/demo_spaces.yaml
+++ b/cfg/demo_spaces.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------

--- a/cfg/t1_rgbd.yaml
+++ b/cfg/t1_rgbd.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------
@@ -48,7 +46,7 @@ env:
     oracle_reveal: 'False'  # If 'True', we compute the occlusion vector every time Blender is called (should only be True if using corner revealing demonstrator)
     use_depth: 'False'      # If 'True', we use depth images for the training process instead of color images
     use_dom_rand: 'True'    # If 'True', we use domain randomization (camera pose, color, etc.)
-    use_rgbd: 'True'
+    use_rgbd: 'True'        # ???
 
 # ------------------------------------------------------------------------------
 # Initialization parameters. Let's assume we can pinpoint one of the four
@@ -61,7 +59,7 @@ env:
 init:
     type: 'tier1'               # Options: tier1, tier2, tier3
     debug_matplotlib: False     # If we show matplotlib video of the initialization
-    render_opengl: True # If we show opengl rendering
+    render_opengl: True         # If we show opengl rendering
 
 # ------------------------------------------------------------------------------
 # Logging. We add the date before the last `.log` in the file name.

--- a/cfg/t1_rgbd.yaml
+++ b/cfg/t1_rgbd.yaml
@@ -46,7 +46,7 @@ env:
     oracle_reveal: 'False'  # If 'True', we compute the occlusion vector every time Blender is called (should only be True if using corner revealing demonstrator)
     use_depth: 'False'      # If 'True', we use depth images for the training process instead of color images
     use_dom_rand: 'True'    # If 'True', we use domain randomization (camera pose, color, etc.)
-    use_rgbd: 'True'        # ???
+    use_rgbd: 'True'        # Added for IROS submission.
 
 # ------------------------------------------------------------------------------
 # Initialization parameters. Let's assume we can pinpoint one of the four

--- a/cfg/t2_rgbd.yaml
+++ b/cfg/t2_rgbd.yaml
@@ -46,7 +46,7 @@ env:
     oracle_reveal: 'False'  # If 'True', we compute the occlusion vector every time Blender is called (should only be True if using corner revealing demonstrator)
     use_depth: 'False'      # If 'True', we use depth images for the training process instead of color images
     use_dom_rand: 'True'    # If 'True', we use domain randomization (camera pose, color, etc.)
-    use_rgbd: 'True'        # ???
+    use_rgbd: 'True'        # Added for IROS submission.
 
 # ------------------------------------------------------------------------------
 # Initialization parameters. Let's assume we can pinpoint one of the four

--- a/cfg/t2_rgbd.yaml
+++ b/cfg/t2_rgbd.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------
@@ -48,7 +46,7 @@ env:
     oracle_reveal: 'False'  # If 'True', we compute the occlusion vector every time Blender is called (should only be True if using corner revealing demonstrator)
     use_depth: 'False'      # If 'True', we use depth images for the training process instead of color images
     use_dom_rand: 'True'    # If 'True', we use domain randomization (camera pose, color, etc.)
-    use_rgbd: 'True'
+    use_rgbd: 'True'        # ???
 
 # ------------------------------------------------------------------------------
 # Initialization parameters. Let's assume we can pinpoint one of the four
@@ -61,7 +59,7 @@ env:
 init:
     type: 'tier2'               # Options: tier1, tier2, tier3
     debug_matplotlib: False     # If we show matplotlib video of the initialization
-    render_opengl: False        # If we show opengl rendering
+    render_opengl: True         # If we show opengl rendering
 
 # ------------------------------------------------------------------------------
 # Logging. We add the date before the last `.log` in the file name.

--- a/cfg/t3_rgbd.yaml
+++ b/cfg/t3_rgbd.yaml
@@ -1,5 +1,3 @@
-# Demonstrate tears and out of bounds stuff.
-
 # ------------------------------------------------------------------------------
 # Cloth parameters, should be loosely based on `cloth_from_184.,yaml`.
 # ------------------------------------------------------------------------------
@@ -48,8 +46,7 @@ env:
     oracle_reveal: 'False'  # If 'True', we compute the occlusion vector every time Blender is called (should only be True if using corner revealing demonstrator)
     use_depth: 'False'      # If 'True', we use depth images for the training process instead of color images
     use_dom_rand: 'True'    # If 'True', we use domain randomization (camera pose, color, etc.)
-    use_rgbd: 'True'
-
+    use_rgbd: 'True'        # ???
 
 # ------------------------------------------------------------------------------
 # Initialization parameters. Let's assume we can pinpoint one of the four
@@ -62,7 +59,7 @@ env:
 init:
     type: 'tier3'               # Options: tier1, tier2, tier3
     debug_matplotlib: False     # If we show matplotlib video of the initialization
-    render_opengl: False        # If we show opengl rendering
+    render_opengl: True         # If we show opengl rendering
 
 # ------------------------------------------------------------------------------
 # Logging. We add the date before the last `.log` in the file name.

--- a/cfg/t3_rgbd.yaml
+++ b/cfg/t3_rgbd.yaml
@@ -46,7 +46,7 @@ env:
     oracle_reveal: 'False'  # If 'True', we compute the occlusion vector every time Blender is called (should only be True if using corner revealing demonstrator)
     use_depth: 'False'      # If 'True', we use depth images for the training process instead of color images
     use_dom_rand: 'True'    # If 'True', we use domain randomization (camera pose, color, etc.)
-    use_rgbd: 'True'        # ???
+    use_rgbd: 'True'        # Added for IROS submission.
 
 # ------------------------------------------------------------------------------
 # Initialization parameters. Let's assume we can pinpoint one of the four

--- a/examples/analytic.py
+++ b/examples/analytic.py
@@ -17,6 +17,7 @@ import datetime
 import cv2
 from gym_cloth.envs import ClothEnv
 from collections import defaultdict
+from scipy.spatial import distance
 np.set_printoptions(edgeitems=10, linewidth=180, suppress=True)
 
 #Adi: Now adding the 'oracle_reveal' demonstrator policy which in reveals occluded corners.
@@ -548,12 +549,175 @@ class HarrisCornerPolicy(Policy):
 
 
 class WrinklesPolicy(Policy):
+    """Approximates the wrinkle-based policy from
+    https://link.springer.com/chapter/10.1007/978-3-662-43645-5_16
+
+    Basically picks max deviation and finds the wrinkle around that
+    rather than k-means + hierarchical clustering. (Their paper does
+    not handle the case of cloth folded on itself.)
+    """
 
     def __init__(self):
         super().__init__()
 
     def get_action(self, obs, t):
-        raise NotImplementedError()
+        """Uses helper methods `is_point_on_top` and `get_neighbors`.
+
+        It uses the 1D cloth array, i.e., the ground truth state.
+        """
+
+        def is_point_on_top(cloth, point):
+            # scan down from z = height in increments of thickness until
+            # the set of points with x,y in grip radius and height in
+            # [z-thickness,z+thickness] is non-empty
+            # all values are copied directly from cfg file, so this is not robust
+            curZ = 1
+            pts = []
+            x = point.x
+            y = point.y
+            while (curZ > 0):
+                for pt in cloth.pts:
+                    if (pt.x-x)*(pt.x-x) + (pt.y-y)*(pt.y-y) < 0.0002 and \
+                        abs(pt.z-curZ) < 2 * 0.02:
+                        pts.append(pt)
+                if pts:
+                    break
+                curZ -= 0.02
+            return point in pts
+
+        def get_neighbors(r, c, cloth):
+            # helper method that gets the 3x3 matrix (or smaller if on boundary)
+            # set of points surrounding the point [r, c]
+            h = cloth.height
+            w = cloth.width
+            points = []
+            points.append(r * w + c)
+            if r > 0 and c > 0:
+                points.append((r - 1) * w + c - 1)
+            if r > 0:
+                points.append((r - 1) * w + c)
+            if c > 0:
+                points.append(r * w + c - 1)
+            if r < h - 1 and c < w - 1:
+                points.append((r + 1) * w + c + 1)
+            if r < h - 1:
+                points.append((r + 1) * w + c)
+            if c < h - 1:
+                points.append(r * w + c + 1)
+            if r > 0 and c < w - 1:
+                points.append((r - 1) * w + c + 1)
+            if r < h - 1 and c > 0:
+                points.append((r + 1) * w + c - 1)
+
+            return points
+
+        # compute deviation map
+        cloth = self.env.cloth
+        h = cloth.height
+        w = cloth.width
+        deviation = []
+        for r in range(h):
+            for c in range(w):
+                if is_point_on_top(cloth, cloth.pts[r * w + c]):
+                    points = np.array([cloth.pts[x].z for x in get_neighbors(r, c, cloth)])
+                    dev = np.sum(np.abs(points - np.mean(points)))
+                    deviation.append(dev)
+                else:
+                    deviation.append(0)
+                # local_dev = [] # local_dev has depth of current point + 8 surrounding points
+                # local_dev.append(cloth.pts[r * w + c].z)
+                # if r > 0 and c > 0:
+                #     local_dev.append(cloth.pts[(r - 1) * w + c - 1].z)
+                # if r > 0:
+                #     local_dev.append(cloth.pts[(r - 1) * w + c].z)
+                # if c > 0:
+                #     local_dev.append(cloth.pts[r * w + c - 1].z)
+                # if r < h - 1 and c < w - 1:
+                #     local_dev.append(cloth.pts[(r + 1) * w + c + 1].z)
+                # if r < h - 1:
+                #     local_dev.append(cloth.pts[(r + 1) * w + c].z)
+                # if c < h - 1:
+                #     local_dev.append(cloth.pts[r * w + c + 1].z)
+                # if r > 0 and c < w - 1:
+                #     local_dev.append(cloth.pts[(r - 1) * w + c + 1].z)
+                # if r < h - 1 and c > 0:
+                #     local_dev.append(cloth.pts[(r + 1) * w + c - 1].z)
+                # dmean = np.mean(local_dev)
+                # dev = sum([np.abs(d - dmean) for d in local_dev]) / 9.0
+                # deviation.append(dev)
+        # approximate largest wrinkle by choosing max deviation
+        p = deviation.index(max(deviation))
+        center = (cloth.pts[p].x, cloth.pts[p].y)
+        print("CENTER:", center)
+        # approximate wrinkle direction by finding the highest deviation out of neighbors
+        c = p % w
+        r = (p - c) // w
+        indices = get_neighbors(r, c, cloth)
+        indices.remove(r * w + c)
+        # indices = []
+        # if r > 0 and c > 0:
+        #     indices.append((r - 1) * w + c - 1)
+        # if r > 0:
+        #     indices.append((r - 1) * w + c)
+        # if c > 0:
+        #     indices.append(r * w + c - 1)
+        # if r < h - 1 and c < w - 1:
+        #     indices.append((r + 1) * w + c + 1)
+        # if r < h - 1:
+        #     indices.append((r + 1) * w + c)
+        # if c < h - 1:
+        #     indices.append(r * w + c + 1)
+        # if r > 0 and c < w - 1:
+        #     indices.append((r - 1) * w + c + 1)
+        # if r < h - 1 and c > 0:
+        #     indices.append((r + 1) * w + c - 1)
+        max_neighbor_index = max(indices, key=lambda index: deviation[index])
+        wrinkle_pt = (cloth.pts[max_neighbor_index].x, cloth.pts[max_neighbor_index].y)
+        print("SECOND WRINKLE PT:", wrinkle_pt)
+        # get perpendicular angle and grab the closest edge or corner on that angle
+        # approximate closest edge of cloth by finding closest cloth point to bed border
+        if wrinkle_pt[0] == center[0]:
+            slope = 1000 # vertical line
+        else:
+            slope = ((wrinkle_pt[1] - center[1]) / (wrinkle_pt[0] - center[0]))
+        perp_slope = -1/slope
+        # print("PERP SLOPE:", perp_slope)
+        x1, x2, y1, y2 = 0, 0, 0, 0
+        if perp_slope > np.sqrt(2) + 1 or perp_slope < -(np.sqrt(2) + 1):
+            # N / S direction
+            # intersection with y = 1
+            x1 = (1 - center[1]) / perp_slope + center[0]
+            y1 = 1
+            # intersection y = 0
+            x2 = (-center[1]) / perp_slope + center[0]
+            y2 = 0
+        elif perp_slope > 1 and perp_slope < np.sqrt(2) + 1:
+            # NE / SW direction - find nearest corner
+            x1, y1 = 1, 1
+            x2, y2 = 0, 0
+        elif perp_slope < np.sqrt(2) - 1 and perp_slope > -(np.sqrt(2) - 1):
+            # E / W direction
+            # intersection with x = 1
+            y1 = perp_slope * (1 - center[0]) + center[1]
+            x1 = 1
+            # intersection x = 0
+            y2 = perp_slope * (-center[0]) + center[1]
+            x2 = 0
+        else:
+            # SE / NW direction - find nearest corner
+            x1, y1 = 0, 1
+            x2, y2 = 1, 0
+        closest_pt1 = min(cloth.pts, key=lambda pt: distance.euclidean((x1, y1), (pt.x, pt.y)))
+        closest_pt2 = min(cloth.pts, key=lambda pt: distance.euclidean((x2, y2), (pt.x, pt.y)))
+        if (distance.euclidean(center, (closest_pt1.x, closest_pt1.y)) < distance.euclidean(center, (closest_pt2.x, closest_pt2.y)) or
+                closest_pt2.x < 0.01 or closest_pt2.x > 0.99 or closest_pt2.y < 0.01 or closest_pt2.y > 0.99): # nowhere to move
+            x, y = closest_pt1.x, closest_pt1.y
+            dx, dy = x1 - x, y1 - y
+        else:
+            x, y = closest_pt2.x, closest_pt2.y
+            dx, dy = x2 - x, y2 - y
+        # print("ACTION:", (x, y, dx, dy))
+        return (2*(x - 0.5), 2*(y - 0.5), dx, dy)  # adjust for self.clip_act_space
 
 
 class HighestPointPolicy(Policy):


### PR DESCRIPTION
At least the code is running. I also did a partial cleanup of the config files. I am pretty sure we used the shorter file names with rgbd in them but please double check.

We have a bunch of config files as well:

```
(py3-cloth) seita@starship:~/gym-cloth (wrinkle-policy) $ ls -lh cfg/
total 112K
-rw-rw-r-- 1 seita seita  821 Mar 18 18:30 cloth_from_184.yaml
-rw-rw-r-- 1 seita seita 4.9K Mar 18 19:21 demo_baselines_fixed_t1_color.yaml
-rw-rw-r-- 1 seita seita 4.9K Mar 18 19:21 demo_baselines_fixed_t1_depth.yaml
-rw-rw-r-- 1 seita seita 4.9K Mar 18 19:21 demo_baselines_fixed_t2_color.yaml
-rw-rw-r-- 1 seita seita 4.9K Mar 18 19:21 demo_baselines_fixed_t2_depth.yaml
-rw-rw-r-- 1 seita seita 4.9K Mar 18 19:21 demo_baselines_fixed_t3_color.yaml
-rw-rw-r-- 1 seita seita 4.9K Mar 18 19:21 demo_baselines_fixed_t3_depth.yaml
-rw-rw-r-- 1 seita seita 4.9K Mar 18 19:20 demo_baselines.yaml
-rw-rw-r-- 1 seita seita 4.0K Mar 18 18:30 demo_bed.yaml
-rw-rw-r-- 1 seita seita 4.1K Mar 18 19:21 demo_render.yaml
-rw-rw-r-- 1 seita seita 4.2K Mar 18 19:21 demo_spaces.yaml
drwxrwxr-x 2 seita seita 4.0K Mar 18 18:30 _json_files
-rw-rw-r-- 1 seita seita  597 Mar 18 18:30 README.md
-rw-rw-r-- 1 seita seita 4.9K Mar 18 19:21 t1_rgbd.yaml
-rw-rw-r-- 1 seita seita 4.9K Mar 18 19:20 t2_rgbd.yaml
-rw-rw-r-- 1 seita seita 4.9K Mar 18 19:20 t3_rgbd.yaml
```

So far we're using `t{}_rgbd.yaml` by defaults. So all of those have the `render_opengl: True` set so it renders ASAP. We also have some arguments like `use_rgbd` for some reason. Do we need those? 


<details>

<summary>
Those must have been for tagging some reproducible settings. Don't worry about the opengl rendering setting. I'm not sure about `use_rgbd` though... 
</summary>

```
(py3-cloth) seita@starship:~/gym-cloth/cfg (wrinkle-policy) $ diff t1_rgbd.yaml  demo_baselines_fixed_t1_color.yaml 
49c49
<     use_rgbd: 'True'        # ???
---
>     use_rgbd: 'False'
62c62
<     render_opengl: True         # If we show opengl rendering
---
>     render_opengl: False        # If we show opengl rendering
74c74
< seed: 1600                      # Random seed -- KEEP FIXED FOR REPRODUCIBILITY!
---
> seed: 1500                      # Random seed -- KEEP FIXED FOR REPRODUCIBILITY!
(py3-cloth) seita@starship:~/gym-cloth/cfg (wrinkle-policy) $ diff t2_rgbd.yaml  demo_baselines_fixed_t2_color.yaml 
49c49
<     use_rgbd: 'True'        # ???
---
>     use_rgbd: 'False'
62c62
<     render_opengl: True         # If we show opengl rendering
---
>     render_opengl: False        # If we show opengl rendering
74c74
< seed: 1600                      # Random seed -- KEEP FIXED FOR REPRODUCIBILITY!
---
> seed: 1500                      # Random seed -- KEEP FIXED FOR REPRODUCIBILITY!
(py3-cloth) seita@starship:~/gym-cloth/cfg (wrinkle-policy) $ diff t3_rgbd.yaml  demo_baselines_fixed_t3_color.yaml 
49c49,50
<     use_rgbd: 'True'        # ???
---
>     use_rgbd: 'False'
> 
62c63
<     render_opengl: True         # If we show opengl rendering
---
>     render_opengl: False        # If we show opengl rendering
74c75
< seed: 1600                      # Random seed -- KEEP FIXED FOR REPRODUCIBILITY!
---
> seed: 1500                      # Random seed -- KEEP FIXED FOR REPRODUCIBILITY!
(py3-cloth) seita@starship:~/gym-cloth/cfg (wrinkle-policy) $ 
```

</details>


This is the commit when it was added: https://github.com/DanielTakeshi/gym-cloth/commit/d44ef4c24b7c35a728f40587f01a4ffdeee623ca
Ah, I remember now, we added this for the IROS submission.